### PR TITLE
Fix issue #2 

### DIFF
--- a/ttf.nim
+++ b/ttf.nim
@@ -1,4 +1,4 @@
-
+import unsigned
 import math
 import algorithm
 


### PR DESCRIPTION
To work with Nim 0.11.2 or earlier, import `unsigned` module.

In Nim 0.11.3 or later, unsigned integer operations are in `system` module.
However, in Nim 0.11.2, unsigned integer operations are in `unsigned` module.
